### PR TITLE
replaced self signal with context cancel

### DIFF
--- a/rpc/daemon.go
+++ b/rpc/daemon.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"fmt"
 	"net/http"
-	"syscall"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
@@ -14,21 +13,19 @@ import (
 
 // DaemonService handles RPC requests for swapd version, administration and (in the future) status requests.
 type DaemonService struct {
-	server *Server
-	pb     ProtocolBackend
+	stopServer func()
+	pb         ProtocolBackend
 }
 
 // NewDaemonService ...
-func NewDaemonService(server *Server, pb ProtocolBackend) *DaemonService {
-	return &DaemonService{
-		server,
-		pb,
-	}
+func NewDaemonService(stopServer func(), pb ProtocolBackend) *DaemonService {
+	return &DaemonService{stopServer, pb}
 }
 
 // Shutdown swapd
-func (s *DaemonService) Shutdown(req *http.Request, _ *any, _ *any) error {
-	return syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+func (s *DaemonService) Shutdown(_ *http.Request, _ *any, _ *any) error {
+	s.stopServer()
+	return nil
 }
 
 // VersionResponse ...

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -61,13 +61,16 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
-	err := rpcServer.RegisterService(NewPersonalService(cfg.Ctx, cfg.XMRMaker, cfg.ProtocolBackend), "personal")
+	serverCtx, serverCancel := context.WithCancel(cfg.Ctx)
+
+	err := rpcServer.RegisterService(NewPersonalService(serverCtx, cfg.XMRMaker, cfg.ProtocolBackend), "personal")
 	if err != nil {
+		serverCancel()
 		return nil, err
 	}
 
 	swapService := NewSwapService(
-		cfg.Ctx,
+		serverCtx,
 		cfg.ProtocolBackend.SwapManager(),
 		cfg.XMRTaker,
 		cfg.XMRMaker,
@@ -75,14 +78,16 @@ func NewServer(cfg *Config) (*Server, error) {
 		cfg.ProtocolBackend,
 	)
 	if err = rpcServer.RegisterService(swapService, "swap"); err != nil {
+		serverCancel()
 		return nil, err
 	}
 
-	wsServer := newWsServer(cfg.Ctx, cfg.ProtocolBackend.SwapManager(), ns, cfg.ProtocolBackend, cfg.XMRTaker)
+	wsServer := newWsServer(serverCtx, cfg.ProtocolBackend.SwapManager(), ns, cfg.ProtocolBackend, cfg.XMRTaker)
 
 	lc := net.ListenConfig{}
-	ln, err := lc.Listen(cfg.Ctx, "tcp", cfg.Address)
+	ln, err := lc.Listen(serverCtx, "tcp", cfg.Address)
 	if err != nil {
+		serverCancel()
 		return nil, err
 	}
 
@@ -98,17 +103,18 @@ func NewServer(cfg *Config) (*Server, error) {
 		ReadHeaderTimeout: time.Second,
 		Handler:           handlers.CORS(headersOk, methodsOk, originsOk)(r),
 		BaseContext: func(listener net.Listener) context.Context {
-			return cfg.Ctx
+			return serverCtx
 		},
 	}
 
 	s := &Server{
-		ctx:        cfg.Ctx,
+		ctx:        serverCtx,
 		listener:   ln,
 		httpServer: server,
 	}
 
-	if err = rpcServer.RegisterService(NewDaemonService(s, cfg.ProtocolBackend), "daemon"); err != nil {
+	if err = rpcServer.RegisterService(NewDaemonService(serverCancel, cfg.ProtocolBackend), "daemon"); err != nil {
+		serverCancel()
 		return nil, err
 	}
 
@@ -145,7 +151,8 @@ func (s *Server) Start() error {
 	case <-s.ctx.Done():
 		// Shutdown below is passed a closed context, which means it will shut down
 		// immediately without servicing already connected clients.
-		if err := s.httpServer.Shutdown(s.ctx); err != nil {
+		err := s.httpServer.Shutdown(s.ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Warnf("http server shutdown errored: %s", err)
 		}
 		// We shut down because the context was cancelled, so that's the error to return


### PR DESCRIPTION
The problem with sending yourself a signal is that it assumes that you want to shutdown the entire process, not just a single swapd daemon that is running in the process. To shutdown the local RPC webserver (which will trigger everything else to shutdown), we don't actually need to cancel the outermost context. Cancelling the context used by the webserver is sufficient. That is what these changes do.